### PR TITLE
ci: Dependabot 設定を追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # 依存は pnpm（package.json + pnpm-lock.yaml）で管理している。
+  # pnpm のロックファイルは npm エコシステムが扱う。
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+      time: "12:00"
+    target-branch: main
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # 定期のバージョン更新だけまとめる。セキュリティ更新は
+      # 個別 PR のまま（applies-to: version-updates）にして、
+      # 1 件ずつ影響を確認できるようにする。
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+      time: "12:00"
+    target-branch: main
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## これはなに？

このリポジトリには `.github/dependabot.yml` が無く、Dependabot のアラートが出ていても自動修正 PR が作られない状態でした。設定を追加します。

現在の未対応アラート（9 件、すべて `pnpm-lock.yaml` の推移的依存）:

| severity | package | 修正版 |
|---|---|---|
| high | brace-expansion | 5.0.7 |
| high | fast-uri | 3.1.5 |
| high | js-yaml | 4.3.1 |
| high | linkify-it | 5.0.2 |
| high | postcss | 8.5.18 |
| medium | postcss | 8.5.23 |

## やったこと

- `npm` エコシステム（pnpm の `package.json` + `pnpm-lock.yaml` を扱う）を週次スケジュールで追加。
- `github-actions` エコシステムを追加し、ワークフローで使う Actions のバージョンも追従させる。
- 定期のバージョン更新は minor/patch をグループ化して PR 数を抑制。**セキュリティ更新は `applies-to: version-updates` によりグループ対象外**＝個別 PR のままなので、1 件ずつ影響を確認できる。

## テスト・動作確認

- [ ] テストコードを実装（設定ファイルのみのため対象外）
- [x] YAML 構文チェック

## その他・備考

- リポジトリ設定側の Dependabot security updates は有効化済みです。マージ後、上記アラートに対する修正 PR が作成されます。
- 既存 CI（lint / typecheck / build / storybook）は `push` と `pull_request` 両方で走るため、依存更新 PR の検証はそのまま機能します。